### PR TITLE
Added shimmer mask width

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Following are the attributes and methods to initialise the demo views.
 |```app:shimmer_demo_layout_manager_type``` | ```setDemoLayoutManager(LayoutManagerType)``` | Layout manager of demo view. Can be one among linear_vertical or linear_horizontal or grid. |
 |```app:shimmer_demo_shimmer_color``` | ``` - ``` | Color reference or value. It can be used to change the color of the shimmer line. |
 |```app:shimmer_demo_angle``` | ``` - ``` | Integer value between 0 and 30 which can modify the angle of the shimmer line. The default value is zero. |
+|```app:shimmer_demo_mask_width``` | ``` setDemoShimmerMaskWidth(float) ``` | Float value between 0 and 1 which can modify the width of the shimmer line. The default value is 0.5. |
 |```app:shimmer_demo_view_holder_item_background``` | ``` - ``` | Color or an xml drawable for the ViewHolder background if you want to achieve the second type of shimmer effect. |
 |```app:shimmer_demo_reverse_animation``` | ``` - ``` | Defines whether the animation should be reversed. If it is true, then the animation starts from the right side of the View. Default value is false. |
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Define your xml as:
         android:id="@+id/shimmer_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:demo_child_count="10"
-        app:demo_grid_child_count="2"
-        app:demo_layout="@layout/layout_demo_grid"
-        app:demo_layout_manager_type="grid"
+        app:shimmer_demo_child_count="10"
+        app:shimmer_demo_grid_child_count="2"
+        app:shimmer_demo_layout="@layout/layout_demo_grid"
+        app:shimmer_demo_layout_manager_type="grid"
         app:shimmer_demo_angle="20"
         />
 

--- a/shimmer/src/main/java/com/cooltechworks/views/shimmer/ShimmerAdapter.java
+++ b/shimmer/src/main/java/com/cooltechworks/views/shimmer/ShimmerAdapter.java
@@ -29,6 +29,7 @@ public class ShimmerAdapter extends RecyclerView.Adapter<ShimmerViewHolder> {
     private int mShimmerAngle;
     private int mShimmerColor;
     private int mShimmerDuration;
+    private float mShimmerMaskWidth;
     private boolean isAnimationReversed;
     private Drawable mShimmerItemBackground;
 
@@ -39,6 +40,7 @@ public class ShimmerAdapter extends RecyclerView.Adapter<ShimmerViewHolder> {
         ShimmerViewHolder shimmerViewHolder = new ShimmerViewHolder(inflater, parent, mLayoutReference);
         shimmerViewHolder.setShimmerColor(mShimmerColor);
         shimmerViewHolder.setShimmerAngle(mShimmerAngle);
+        shimmerViewHolder.setShimmerMaskWidth(mShimmerMaskWidth);
         shimmerViewHolder.setShimmerViewHolderBackground(mShimmerItemBackground);
         shimmerViewHolder.setShimmerAnimationDuration(mShimmerDuration);
         shimmerViewHolder.setAnimationReversed(isAnimationReversed);
@@ -66,6 +68,10 @@ public class ShimmerAdapter extends RecyclerView.Adapter<ShimmerViewHolder> {
 
     public void setShimmerColor(int shimmerColor) {
         this.mShimmerColor = shimmerColor;
+    }
+
+    public void setShimmerMaskWidth(float maskWidth) {
+        this.mShimmerMaskWidth = maskWidth;
     }
 
     public void setShimmerItemBackground(Drawable shimmerItemBackground) {

--- a/shimmer/src/main/java/com/cooltechworks/views/shimmer/ShimmerRecyclerView.java
+++ b/shimmer/src/main/java/com/cooltechworks/views/shimmer/ShimmerRecyclerView.java
@@ -65,6 +65,7 @@ public class ShimmerRecyclerView extends RecyclerView {
         int mShimmerAngle;
         int mShimmerColor;
         int mShimmerDuration;
+        float mShimmerMaskWidth;
         boolean isAnimationReversed;
         Drawable mShimmerItemBackground;
 
@@ -92,6 +93,7 @@ public class ShimmerRecyclerView extends RecyclerView {
             mShimmerColor = a.getColor(R.styleable.ShimmerRecyclerView_shimmer_demo_shimmer_color, getColor(R.color.default_shimmer_color));
             mShimmerItemBackground = a.getDrawable(R.styleable.ShimmerRecyclerView_shimmer_demo_view_holder_item_background);
             mShimmerDuration = a.getInteger(R.styleable.ShimmerRecyclerView_shimmer_demo_duration, 1500);
+            mShimmerMaskWidth = a.getFloat(R.styleable.ShimmerRecyclerView_shimmer_demo_mask_width, 0.5f);
             isAnimationReversed = a.getBoolean(R.styleable.ShimmerRecyclerView_shimmer_demo_reverse_animation, false);
         } finally {
             a.recycle();
@@ -99,6 +101,7 @@ public class ShimmerRecyclerView extends RecyclerView {
 
         mShimmerAdapter.setShimmerAngle(mShimmerAngle);
         mShimmerAdapter.setShimmerColor(mShimmerColor);
+        mShimmerAdapter.setShimmerMaskWidth(mShimmerMaskWidth);
         mShimmerAdapter.setShimmerItemBackground(mShimmerItemBackground);
         mShimmerAdapter.setShimmerDuration(mShimmerDuration);
         mShimmerAdapter.setAnimationReversed(isAnimationReversed);
@@ -140,6 +143,16 @@ public class ShimmerRecyclerView extends RecyclerView {
      */
     public void setDemoShimmerDuration(int duration) {
         mShimmerAdapter.setShimmerDuration(duration);
+    }
+
+    /**
+     * Specifies the the width of the shimmer line.
+     *
+     * @param maskWidth - float specifying the width of shimmer line. The value should be from 0 to less or equal to 1.
+     *                  The default value is 0.5.
+     */
+    public void setDemoShimmerMaskWidth(float maskWidth) {
+        mShimmerAdapter.setShimmerMaskWidth(maskWidth);
     }
 
     /**

--- a/shimmer/src/main/java/com/cooltechworks/views/shimmer/ShimmerViewHolder.java
+++ b/shimmer/src/main/java/com/cooltechworks/views/shimmer/ShimmerViewHolder.java
@@ -44,6 +44,10 @@ public class ShimmerViewHolder extends RecyclerView.ViewHolder {
         mShimmerLayout.setShimmerColor(color);
     }
 
+    public void setShimmerMaskWidth(float maskWidth) {
+        mShimmerLayout.setMaskWidth(maskWidth);
+    }
+
     public void setShimmerViewHolderBackground(Drawable viewHolderBackground) {
         if (viewHolderBackground != null) {
             setBackground(viewHolderBackground);

--- a/shimmer/src/main/res/values/attrs.xml
+++ b/shimmer/src/main/res/values/attrs.xml
@@ -30,6 +30,7 @@ limitations under the License.
         <attr name="shimmer_demo_angle" format="integer|reference" />
         <attr name="shimmer_demo_view_holder_item_background" format="color|reference" />
         <attr name="shimmer_demo_duration" format="integer|reference" />
+        <attr name="shimmer_demo_mask_width" format="float|reference" />
         <attr name="shimmer_demo_reverse_animation" format="boolean|reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This PR adds the ability to tweak the default value for the shimmer line width.

Keeps compatibility with the old implementation adding the default to 0.5f that is the same in `ShimmerLayout`.